### PR TITLE
[XiaoQu] #N/A feat: add cdrv for dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
   "homepage": "https://github.com/li-qiang/cz-jira#readme",
   "dependencies": {
     "@types/yamljs": "^0.2.31",
+    "@types/node": "^14.14.37",
     "commitizen": "^4.2.3",
     "conventional-commit-types": "^3.0.0",
     "gitconfig": "^2.0.8",
+    "inquirer-search-list": "^1.2.6",
     "longest": "^2.0.1",
     "yamljs": "^0.3.0"
   },

--- a/src/custom-commit-types.ts
+++ b/src/custom-commit-types.ts
@@ -1,0 +1,34 @@
+export default {
+  "ops": {
+    "test": {
+      "description": "测试功能/新方案测验的提交",
+      "title": "test"
+    },
+    "feat": {
+      "description": "新旧功能变更的提交",
+      "title": "feat"
+    },
+    "patch": {
+      "description": "漏洞修复补丁升级的提交",
+      "title": "patch"
+    },
+    "rollback": {
+      "description": "服务回滚的提交",
+      "title": "rollback"
+    },
+    "daily": {
+      "description": "日常重复工作，比如添加成员的提交",
+      "title": "daily"
+    },
+    "docs": {
+      "description": "README、annotation、help文档",
+      "title": "docs"
+    }
+  },
+  "dev":{
+    "CDRV": {
+      "description": "fix code review feedback.",
+      "title": "Code Review"
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,33 @@
 import process from 'process';
+import fs from 'fs';
 import {Answer, Inquirer} from "inquirer";
+import customCommitTypes from './custom-commit-types';
 import longest = require('longest');
 import commitTypes = require('conventional-commit-types');
 import commitizen = require('commitizen');
 import gitconfig = require('gitconfig');
 
-const fs = require('fs');
 
-var config = commitizen.configLoader.load() || {};
+const config = commitizen.configLoader.load() || {};
+const length = longest(Object.keys(commitTypes.types)).length + 1;
 
-var length = longest(Object.keys(commitTypes.types)).length + 1;
+const options = {
+  defaultType: process.env.CZ_TYPE || config.defaultType,
+  defaultIssue: process.env.CZ_ISSUE || config.defaultIssue,
+  emailDomain: config.emailDomain,
+  userRole: config.userRole,
+};
 
-const types = Object.entries(commitTypes.types)
+let roleCustomCommitType: commitTypes.TypeMap =
+  options.userRole === 'ops' ? customCommitTypes.ops : customCommitTypes.dev;
+
+const types = Object.entries({...commitTypes.types, ...roleCustomCommitType})
   .map(([key, value]) => {
     return {
       name: (key + ':').padEnd(length) + ' ' + value.description,
       value: key
     }
   });
-
-const options = {
-  defaultType: process.env.CZ_TYPE || config.defaultType,
-  defaultIssue: process.env.CZ_ISSUE || config.defaultIssue,
-  emailDomain: config.emailDomain,
-
-};
 
 
 const validateEmail = (email: string) => {
@@ -39,30 +42,32 @@ function cacheAnswer(answer: Answer) {
   config.defaultIssue = answer.issue;
   config.defaultType = answer.type;
   const homedir = require('os').homedir();
-  fs.writeFile(`${homedir}/.czrc`, JSON.stringify(config), () => {})
+  fs.writeFile(`${homedir}/.czrc`, JSON.stringify(config), () => {
+  })
 }
 
 export const prompter = async (cz: Inquirer, commit: (msg: string) => void) => {
   const user = await gitconfig.get({location: 'global'}).then((config) => config.user);
+  // register searchable list plugin;
+  cz.registerPrompt('search-list', require('inquirer-search-list'));
 
-  cz
-    .prompt([{
-      name: 'issue',
-      type: 'input',
-      message: 'Input jira issue key:',
-      default: options.defaultIssue
-    }, {
-      type: 'list',
-      name: 'type',
-      message: "Select the type of change that you're committing:",
-      choices: types,
-      default: options.defaultType
-    }, {
-      name: 'body',
-      type: 'input',
-      message: 'Input message content:',
-    }])
-    .then(answer => {
+  cz.prompt([{
+    name: 'issue',
+    type: 'input',
+    message: 'Input jira issue key:',
+    default: options.defaultIssue
+  }, {
+    type: 'search-list',
+    name: 'type',
+    message: "Select the type of change that you're committing:",
+    choices: types,
+    default: options.defaultType
+  }, {
+    name: 'body',
+    type: 'input',
+    message: 'Input message content:',
+  }])
+    .then((answer: Answer) => {
       validateEmail(user.email);
       cacheAnswer(answer);
       commit(`[${user.name}] #${answer.issue} ${answer.type}: ${answer.body}`);

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -5,7 +5,6 @@ declare module 'conventional-commit-types' {
 
 }
 
-
 declare module 'longest' {
   function longest(strs: string[]): string
 
@@ -37,5 +36,6 @@ declare module 'inquirer' {
 
   export interface Inquirer {
     prompt(any): Promise<Answer>
+    registerPrompt(pluginName: string, module: any): void;
   }
 }


### PR DESCRIPTION
1.  split dev && ops types by (`.czrc` ```{'userRole': 'ops'}```), also it's transparent for `devs`
2. add types searchable by typing in terminal